### PR TITLE
upgrade jackson to 2.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <jacoco.enabled>true</jacoco.enabled>
     <jacoco.version>0.8.4</jacoco.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <jackson.version>2.10.2</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
   </properties>
 
   <profiles>
@@ -237,14 +237,8 @@
       <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
   </dependencies>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>


### PR DESCRIPTION
# What Changed
Upgrading jackson to latest version.  Also removing jackson databind as it is not used yet.

# Why
Security vulnerabilities

Todo:

- [ ] Add tests - NA
- [ ] Add docs  - NA